### PR TITLE
Fix manage reservations sort

### DIFF
--- a/public/js/manage-reservations.js
+++ b/public/js/manage-reservations.js
@@ -51,7 +51,8 @@ $(document).ready(function () {
 	});
 
 	$("#searchBox").on("keyup paste", function () {
-		console.log($(this).val())
+		let str = $(this).val();
+		$(this).val(str.substring(0, 15));
 		$('#otherReservationsTable').DataTable()
 			.search($(this).val())
 			.draw();


### PR DESCRIPTION
**Bugs Fixed:**

1. [studentRep Manage Reservations- Sort] The table extends whenever the description for borrowing is quite long
2. [studentRep Manage Reservations- Sort] The Search Box for ID Numbers accepts string with a length of 100 