### PR TITLE
fixed text overflow on reserve equipment UI

### DIFF
--- a/public/css/styles-equipment.css
+++ b/public/css/styles-equipment.css
@@ -73,3 +73,11 @@
 .equipment-card:hover .equipment-img {
     transform: translateY(-68px);
 }
+
+.btn.btn-toggle {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}


### PR DESCRIPTION
**Bug Fixed:**

- [Rent Equipment] Front End for the Equipment Choices. The titles don't fit in the box and extend from their container