### PR TITLE
Fix student rep manage reservations

### DIFF
--- a/controller/reservations.controller.js
+++ b/controller/reservations.controller.js
@@ -555,6 +555,7 @@ async function setAllPendingToDenied (hours, minutes) {
  */
 function isValidPaymentDate(date) {
     let today = new Date();
+    today.setUTCHours(0,0,0,0)
     return date >= today;
 }
 exports.isValidPaymentDate = isValidPaymentDate;

--- a/public/js/manage-reservations.js
+++ b/public/js/manage-reservations.js
@@ -219,7 +219,7 @@ $('#editReservationModal').on('show.bs.modal', (event) => {
 			remarks: btn.data('remarks'),
 			penalty: btn.data('penalty'),
 			type: btn.data('type'),
-			paymentDate: btn.data('paymentdate')
+			pickupPayDate: btn.data('paymentdate')
 		}
 	} else
 		reservation = $('#otherReservationsTable').DataTable().row(event.relatedTarget).data();
@@ -245,7 +245,7 @@ $('#editReservationModal').on('show.bs.modal', (event) => {
 		}
 	);
 
-	var payDate = reservation.paymentDate == '' ? new Date() : new Date(reservation.paymentDate);
+	var payDate = (reservation.pickupPayDate === '' || reservation.pickupPayDate === null) ? new Date() : new Date(reservation.pickupPayDate);
 	var payDateString = payDate.getFullYear() + '-'
 		+ ((payDate.getMonth() <= 8) ? '0' : '') + (payDate.getMonth() + 1) + '-'
 		+ ((payDate.getDate() <= 9) ? '0' : '') + payDate.getDate();
@@ -304,8 +304,7 @@ $('#editReservationModal').on('show.bs.modal', (event) => {
 	}
 	$('.select-selected').show();
 
-	var pickupPayText;
-	if (reservation.type == 'Locker')
+	if (reservation.onItemType === 'Locker' || reservation.type === 'Locker')
 		$('[value="status-manage-pickup-pay"]').text('To Pay')
 	else
 		$('[value="status-manage-pickup-pay"]').text('For Pickup')
@@ -348,10 +347,13 @@ $('#editReservationModal').on('show.bs.modal', (event) => {
 		else
 			$('#penaltyForm').css('display', 'none');
 
-		if (status == 'status-manage-pickup-pay' && reservation.type == 'Locker')
+		if (status == 'status-manage-pickup-pay' && (reservation.type === 'Locker' ||
+			reservation.onItemType === 'Locker'))
 			$('#paymentForm').css('display', 'flex');
 		else
 			$('#paymentForm').css('display', 'none');
+
+
 	});
 
 	$('#status').change();

--- a/views/manage-reservations-page.hbs
+++ b/views/manage-reservations-page.hbs
@@ -274,7 +274,7 @@
                 </div>
               </div>
               <div class="form-group form-inline input-group" id="paymentForm">
-                <label for="paymentForm" class="col-lg-4 justify-content-start pl-2">Deadline of Payment</label>
+                <label for="paymentDate" class="col-lg-4 justify-content-start pl-2">Deadline of Payment</label>
                 <input type="date" class="form-control col-lg-8" name="paymentDate" id="paymentDate">
               </div>
               <div class="form-group form-inline input-group" id="remarksForm">


### PR DESCRIPTION
Bugs fixed: 
1. [studentRep Manage Reservations] Denied status is not automatically set if equipment reservation of a given is still Pending one hour before the pick up time
2. [Student Representative] Cannot approve or deny reservations
3. [studentRep Manage Reservations] Locker reservations in the Other Reservations section displays the choice of For Pickup rather than To Pay