### PR TITLE
fixed delete btn not showing in some cases

### DIFF
--- a/public/js/manage-reservations.js
+++ b/public/js/manage-reservations.js
@@ -297,9 +297,11 @@ $('#editReservationModal').on('show.bs.modal', (event) => {
 			break;
 		case 'Returned':
 			$('[value="status-manage-returned"]').prop('disabled', false).show();
+			$('#deleteReservationBtn').show();
 			break;
 		case 'Denied':
 			$('[value="status-manage-denied"]').prop('disabled', false).show();
+			$('#deleteReservationBtn').show();
 			break;
 	}
 	$('.select-selected').show();


### PR DESCRIPTION
**Bug Fixed:**
[Deleting Reservations] The Student Representative Cannot Delete Reservations with a Denied Status after clicking other reservations with status except Returned/Denied