### PR TITLE
fixed comparing of rental hours

### DIFF
--- a/controller/panel.controller.js
+++ b/controller/panel.controller.js
@@ -144,6 +144,7 @@ exports.set_rental_dates = async function (req, res) {
         returnDate.setHours(23, 59, 59, 0);
 
         if (isValidRentalDates(startDate, endDate, returnDate)){
+
             let rentalDateConfig = await RentalDates.findOne();
             if (rentalDateConfig) {
                 await RentalDates.findOneAndUpdate({}, {
@@ -320,8 +321,19 @@ function isPanelDeletable(lockers) {
 }
 
 function isValidRentalDates(startDate, endDate, returnDate) {
+    let flag = false;
     let currentDate = new Date();
-    return (startDate >= currentDate) && (endDate >= startDate) && (returnDate > endDate);
+
+    startDate.setMinutes(startDate.getMinutes() + 1);
+    returnDate.setHours(endDate.getHours(), endDate.getMinutes(), 0);
+
+    if ((startDate >= currentDate) && (endDate >= startDate) && (returnDate > endDate))
+        flag = true;
+
+    startDate.setMinutes(startDate.getMinutes() - 1);
+    returnDate.setHours(23, 59, 59);
+
+    return flag;
 }
 
 exports.getMissingPanelNumber = getMissingPanelNumber;

--- a/public/js/manage-lockers.js
+++ b/public/js/manage-lockers.js
@@ -320,9 +320,11 @@ function isValidEndDate () {
     let endDateObject = new Date(endDate);
 
     let startTimeString = $("#startTime").val();
+
     let startTimeHour = startTimeString.split(':')[0];
     let startTimeMinute = startTimeString.split(':')[1];
     startDateObject.setHours(startTimeHour, startTimeMinute, 0);
+    startDateObject.setMinutes(startDateObject.getMinutes() + 1);
 
     let endTimeString = $("#endTime").val();
     let endTimeHour = endTimeString.split(':')[0];
@@ -337,13 +339,6 @@ function isValidReturnDate() {
     let returnDate = $("#returnDate").val();
     let endDateObject = new Date(endDate);
     let returnDateObject = new Date(returnDate);
-
-    let endTimeString = $("#endTime").val();
-    let endTimeHour = endTimeString.split(':')[0];
-    let endTimeMinute = endTimeString.split(':')[1];
-    endDateObject.setHours(endTimeHour, endTimeMinute, 0);
-
-    returnDateObject.setHours(23, 59, 59);
 
     return returnDateObject > endDateObject;
 }


### PR DESCRIPTION
Bug fixes for:
1. [Set Rental Dates-Lockers] End time is accepted even though it is equal with the start time when the start and end date are the same
2. [Set Rental Dates-Lockers] Setting locker rental dates is successful even when return date and end rental date is the same.
